### PR TITLE
The sudo parameter should be directly specified in the playbook

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,7 +1,7 @@
 ---
 rvm:
   url: https://get.rvm.io
-  temp_installer_path: /root/rvm-installer.sh
+  temp_installer_path: /tmp/rvm-installer.sh
 
   root: /usr/local/rvm
   init_script: /etc/profile.d/rvm.sh

--- a/tasks/install_rvm.yml
+++ b/tasks/install_rvm.yml
@@ -21,4 +21,3 @@
 
 - name: setting RVM autolibs on
   command: "{{rvm.root}}/bin/rvm autolibs 3"
-  sudo: "{{ sudo }}"

--- a/tasks/receive_key.yml
+++ b/tasks/receive_key.yml
@@ -1,4 +1,3 @@
 ---
 - name: receiving key
   shell: "gpg2 --keyserver hkp://keys.gnupg.net --recv-keys D39DC0E3"
-  sudo: "{{ sudo }}"

--- a/tasks/select_ruby.yml
+++ b/tasks/select_ruby.yml
@@ -1,7 +1,6 @@
 ---
 - name: setting default Ruby version
   shell: "source {{rvm.init_script}} && rvm use {{rvm.default_ruby_version}} --default executable=/bin/bash"
-  sudo: "{{ sudo }}"
   register: rvm_select_ruby_version
   ignore_errors: True
   changed_when: False

--- a/tasks/update_rvm.yml
+++ b/tasks/update_rvm.yml
@@ -3,4 +3,3 @@
 
 - name: updating RVM
   shell: "source {{rvm.init_script}} && rvm get stable executable=/bin/bash"
-  sudo: "{{ sudo }}"


### PR DESCRIPTION
When the `sudo` parameter is absent from the tasks, the configuration is taken from the playbook.
If `sudo` is set on the tasks, it breaks and fails to execute the tasks as root.

cc @christopherobin 
