### PR TITLE
Refactor, deprecation fixes and tasks flow improved

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,8 @@
 Ansible RVM role
 ================
 
-This Ansible role installs RVM as root and the required ruby version.
-If user isn't root (executing without sudo) then RVM will be installed to the user home directory,
-but you need to change paths to it own RVM through variables `rvm_root` and `rvm_init_script`.
+This Ansible role installs RVM and the required ruby version.
+Installation is possible for system or for single user (without root privileges)
 
 Requirements
 ------------
@@ -27,7 +26,14 @@ Role Variables
 
 The last two variables are set according to whether a `system`-wide install (Multi-User install), or a Single-User install has been chosen with `rvm_install_type`.
 
-The playbook runs with root permissions by default if the `ansible_ssh_user` that is running your playbook has `sudo` privileges, and `rvm_install_type` is set to `system`.
+The palybook should runs on user with sufficient permissions:
+- to install dependencies via `apt` or `yum` if you do not have installed `curl` and `gnupg2` pakages
+- to install dependencies via `apt` or `yum` if you set `rvm_autolibs` to `3` or `4` (default `3`)
+- to install in system path for example in `system` mode (`rvm_install_type`  variable) 
+
+If you want to install on unprivileged user you should have system dependencies installed and set:
+- `rvm_install_type` to `user`
+- `rvm_autolibs` prefably to `2`
 
 When the playbook is run with `rvm_install_type = user`, the playbook will install RVM to the home directory of the `ansible_ssh_user`.
 The defaults for the last two variables are then:

--- a/tasks/install_packages.yml
+++ b/tasks/install_packages.yml
@@ -4,7 +4,6 @@
     name: "{{ item }}"
     state: present
   with_items: "{{ rvm_required_packages }}"
-  sudo: true
   when: ansible_os_family == "RedHat"
 
 - name: ensure necessary apt packages are installed
@@ -12,5 +11,4 @@
     name: "{{ item }}"
     state: present
   with_items: "{{ rvm_required_packages }}"
-  sudo: true
   when: ansible_os_family == "Debian"

--- a/tasks/install_ruby.yml
+++ b/tasks/install_ruby.yml
@@ -1,12 +1,5 @@
 ---
-- name: installing Ruby as root
+- name: Install Ruby
   command: "{{rvm_root}}/bin/rvm install {{rvm_default_ruby_version}}"
-  sudo: true
-  when: "'{{ rvm_install_type }}' == 'system'"
-
-- name: installing Ruby as user
-  command: "{{rvm_root}}/bin/rvm install {{rvm_default_ruby_version}}"
-  sudo: false
-  when: "'{{ rvm_install_type }}' == 'user'"
 
 - include: ./select_ruby.yml

--- a/tasks/install_ruby.yml
+++ b/tasks/install_ruby.yml
@@ -2,4 +2,4 @@
 - name: Install Ruby
   command: "{{rvm_root}}/bin/rvm install {{rvm_default_ruby_version}}"
 
-- include: ./select_ruby.yml
+- include_tasks: ./select_ruby.yml

--- a/tasks/install_rvm.yml
+++ b/tasks/install_rvm.yml
@@ -1,36 +1,23 @@
 ---
 - include: ./receive_key.yml
 
-- name: downloading RVM installer
+- name: Download RVM installer
   get_url:
     url: "{{rvm_url}}"
     dest: "{{rvm_temp_installer_path}}"
 
-- name: set executable RVM installer
+- name: Set RVM installer to be executable
   file:
     path: "{{rvm_temp_installer_path}}"
     mode: 0755
 
-- name: installing RVM as root
+- name: Install RVM
   command: "{{rvm_temp_installer_path}} --path {{rvm_root}} stable"
-  sudo: true
-  when: "'{{ rvm_install_type }}' == 'system'"
 
-- name: installing RVM as user
-  command: "{{rvm_temp_installer_path}} --path {{rvm_root}} stable"
-  sudo: false
-
-- name: removing RVM installer
+- name: Remove RVM installer
   file:
     path: "{{rvm_temp_installer_path}}"
     state: absent
 
-- name: setting RVM autolibs option as root
+- name: Set RVM autolibs option
   command: "{{rvm_root}}/bin/rvm autolibs {{rvm_autolibs}}"
-  sudo: true
-  when: "'{{ rvm_install_type }}' == 'system'"
-
-- name: setting RVM autolibs option as user
-  command: "{{rvm_root}}/bin/rvm autolibs {{rvm_autolibs}}"
-  sudo: false
-  when: "'{{ rvm_install_type }}' == 'user'"

--- a/tasks/install_rvm.yml
+++ b/tasks/install_rvm.yml
@@ -1,5 +1,5 @@
 ---
-- include: ./receive_key.yml
+- include_tasks: ./receive_key.yml
 
 - name: Download RVM installer
   get_url:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,10 +1,10 @@
 ---
-- name: include install type vars
+- name: Include install type vars
   include_vars: "{{ rvm_install_type }}.yml"
 
 - include: ./install_packages.yml
 
-- name: checking that RVM is installed
+- name: Check if RVM installed
   stat:
     path: "{{rvm_init_script}}"
   ignore_errors: True
@@ -20,4 +20,4 @@
 - include: ./select_ruby.yml
 
 - include: ./install_ruby.yml
-  when: rvm_select_ruby_version_user|failed or rvm_select_ruby_version_root|failed
+  when: rvm_select_ruby_version is defined and rvm_select_ruby_version.rc != 0

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -2,7 +2,7 @@
 - name: Include install type vars
   include_vars: "{{ rvm_install_type }}.yml"
 
-- include: ./install_packages.yml
+- include_tasks: ./install_packages.yml
 
 - name: Check if RVM installed
   stat:
@@ -11,13 +11,13 @@
   failed_when: False
   register: rvm_install_result
 
-- include: ./install_rvm.yml
+- include_tasks: ./install_rvm.yml
   when: rvm_install_result.stat.exists != true
 
-- include: ./update_rvm.yml
+- include_tasks: ./update_rvm.yml
   when: rvm_auto_update_rvm and rvm_install_result.stat.exists == true
 
-- include: ./select_ruby.yml
+- include_tasks: ./select_ruby.yml
 
-- include: ./install_ruby.yml
+- include_tasks: ./install_ruby.yml
   when: rvm_select_ruby_version is defined and rvm_select_ruby_version.rc != 0

--- a/tasks/receive_key.yml
+++ b/tasks/receive_key.yml
@@ -9,4 +9,6 @@
 
 - name: Install GPG key
   shell: "curl -sSL https://rvm.io/mpapis.asc | gpg --import -"
+  args:
+    warn: False
   when: mpapis_gpg_key_exists is defined and mpapis_gpg_key_exists.rc is defined and mpapis_gpg_key_exists.rc != 0

--- a/tasks/receive_key.yml
+++ b/tasks/receive_key.yml
@@ -1,24 +1,12 @@
 ---
-- name: Check for mpapis gpg key as root
+- name: Check for mpapis gpg key
   shell: gpg --list-keys mpapis
-  sudo: true
   register: mpapis_gpg_key_exists
-  ignore_errors: true
-  when: "'{{ rvm_install_type }}' == 'system'"
+  ignore_errors: True
+  changed_when: False
+  failed_when: False
 
-- name: receiving key as root
+
+- name: Install GPG key
   shell: "curl -sSL https://rvm.io/mpapis.asc | gpg --import -"
-  sudo: true
-  when: mpapis_gpg_key_exists is defined and mpapis_gpg_key_exists.rc is defined and mpapis_gpg_key_exists.rc != 0 and '{{ rvm_install_type }}' == 'system'
-
-- name: Check for mpapis gpg key as user
-  shell: gpg --list-keys mpapis
-  sudo: false
-  register: mpapis_gpg_key_exists
-  ignore_errors: true
-  when: "'{{ rvm_install_type }}' == 'user'"
-
-- name: receiving key as user
-  shell: "curl -sSL https://rvm.io/mpapis.asc | gpg --import -"
-  sudo: false
-  when: mpapis_gpg_key_exists is defined and mpapis_gpg_key_exists.rc is defined and mpapis_gpg_key_exists.rc != 0 and '{{ rvm_install_type }}' == 'user'
+  when: mpapis_gpg_key_exists is defined and mpapis_gpg_key_exists.rc is defined and mpapis_gpg_key_exists.rc != 0

--- a/tasks/select_ruby.yml
+++ b/tasks/select_ruby.yml
@@ -1,17 +1,7 @@
 ---
-- name: setting default Ruby version as root
+- name: Check if desired Ruby installed and default
   shell: "source {{rvm_init_script}} && rvm use {{rvm_default_ruby_version}} --default executable=/bin/bash"
-  sudo: true
-  register: rvm_select_ruby_version_root
+  register: rvm_select_ruby_version
   ignore_errors: True
   failed_when: False
   changed_when: False
-  when: "'{{ rvm_install_type }}' == 'system'"
-
-- name: setting default Ruby version as user
-  shell: "source {{rvm_init_script}} && rvm use {{rvm_default_ruby_version}} --default executable=/bin/bash"
-  sudo: false
-  register: rvm_select_ruby_version_user
-  ignore_errors: True
-  changed_when: False
-  when: "'{{ rvm_install_type }}' == 'user'"

--- a/tasks/update_rvm.yml
+++ b/tasks/update_rvm.yml
@@ -1,12 +1,6 @@
 ---
 - include: ./receive_key.yml
 
-- name: updating RVM as root
+- name: Update RVM
   shell: "source {{rvm_init_script}} && rvm get stable executable=/bin/bash"
-  sudo: true
-  when: "'{{ rvm_install_type }}' == 'system'"
-
-- name: updating RVM as user
-  shell: "source {{rvm_init_script}} && rvm get stable executable=/bin/bash"
-  sudo: false
-  when: "'{{ rvm_install_type }}' == 'user'"
+  

--- a/tasks/update_rvm.yml
+++ b/tasks/update_rvm.yml
@@ -1,5 +1,5 @@
 ---
-- include: ./receive_key.yml
+- include_tasks: ./receive_key.yml
 
 - name: Update RVM
   shell: "source {{rvm_init_script}} && rvm get stable executable=/bin/bash"


### PR DESCRIPTION
Redesigned `system` and `user` installations:
 - Removed code duplicates with `sudo` atrribute.
 - Removed `sudo` attribute which is not supported currently in ansible.
 - If `system` installation needs to escalate it should be done like this:
   ```yaml
   roles:
     { role: AerisCloud.rvm, become: true, become_user: root, become_method: sudo }`
   ```

Changed tasks to to properly report state:
 - `Failed` - only when real error occurs
 - `Changed` - when some action needed and job done with success
 - `Ok` - in other cases when action is not required or for check actions

Warnings resolved:
 - `include` changed to `include_tasks` for task inclusion due to deprecation
 - Muted warning about using curl in shell because ansible recommends other module